### PR TITLE
fix typo on bridget + requirejs example

### DIFF
--- a/content/extras.hbs
+++ b/content/extras.hbs
@@ -36,7 +36,7 @@ requirejs( [
 requirejs( [ 'require', 'jquery', 'path/to/masonry.pkgd.js' ],
   function( require, $, Masonry ) {
     // require jquery-bridget, it's included in masonry.pkgd.js
-    require( [ 'jquery-bridget/jquery-bridget' ],
+    require( [ 'jquery-bridget/jquery.bridget' ],
     function( jQueryBridget ) {
       // make Masonry a jQuery plugin
       jQueryBridget( 'masonry', Masonry, $ );


### PR DESCRIPTION
typo hyphen instead of dot