### PR TITLE
Remove Google Analytics

### DIFF
--- a/templates/page.hbs
+++ b/templates/page.hbs
@@ -57,15 +57,5 @@
   <script src="{{#if page.is404}}/{{/if}}js/masonry-docs.min.js?2"></script>
 {{/if}}
 
-{{#unless isExport}}
-  <!-- Google Analytics - Remove this if you copy/pasted this page -->
-  <script>
-    var _gaq=[['_setAccount','UA-592624-5'],['_trackPageview'],['_setDomainName', 'desandro.com']];
-    (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.async=1;
-    g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js';
-    s.parentNode.insertBefore(g,s)}(document,'script'));
-  </script>
-{{/unless}}
-
 </body>
 </html>


### PR DESCRIPTION
Would you be willing to remove this Google Analytics 'functionality' from this website? There are better alternatives if you _must_ keep tabs on users' activity.

Some reputable alternatives can be seen here: https://switching.software/replace/google-analytics/